### PR TITLE
JE-53068 Replace the web admin tool with the Mongo-express

### DIFF
--- a/addons/auto-cluster.yaml
+++ b/addons/auto-cluster.yaml
@@ -67,6 +67,7 @@ actions:
   init: 
     - sleep: 3000
     - cmd[${nodes.nosqldb.master.id}]: jcm initCluster ${nodes.nosqldb.join(id,)}
+    - cmd[nosqldb]: jcm restartAdminApp
 
   add:
     - cmd[${nodes.nosqldb.master.id}]: jcm addMember ${this}


### PR DESCRIPTION
Web admin tool must be restarted AFTER the replica set initialization to start in the proper way with needed options and successfully commect to the replica set